### PR TITLE
URL Cleanup

### DIFF
--- a/priv/www-examples/WhiteRabbitBoard/index.html
+++ b/priv/www-examples/WhiteRabbitBoard/index.html
@@ -136,7 +136,7 @@
 			});
 		} else {
 			var ffb = new Image();
-			ffb.src = "http://www.mozilla.org/products/firefox/buttons/getfirefox_large2.png";
+			ffb.src = "https://www.mozilla.org/products/firefox/buttons/getfirefox_large2.png";
 			document.getElementById("controls").style.display = "none";
 			document.getElementById("noCanvas").style.display = "block";
 			document.getElementById("ffbutton").src = ffb.src;
@@ -197,8 +197,8 @@
 <pre id="testOutput"></pre>
 
 <div id="noCanvas" style="display:none;">
-	<center>This software requires <a href="http://www.mozilla.com/firefox/">Mozilla Firefox 1.5</a> or Opera 8.5</center><br/><br/>
-	<center><a href="http://www.getfirefox.net/"
+	<center>This software requires <a href="https://www.mozilla.com/firefox/">Mozilla Firefox 1.5</a> or Opera 8.5</center><br/><br/>
+	<center><a href="https://www.getfirefox.net:443/"
 title="Get Firefox - Web browsing redefined."><img id="ffbutton"
 src=""
 width="178" height="60" border="0" alt="Get Firefox"></a> </center>

--- a/priv/www-examples/WhiteRabbitBoard/painter/cp_depends.js
+++ b/priv/www-examples/WhiteRabbitBoard/painter/cp_depends.js
@@ -1,7 +1,7 @@
 /*
 	Base, version 1.0.1
 	Copyright 2006, Dean Edwards
-	License: http://creativecommons.org/licenses/LGPL/2.1/
+	License: https://creativecommons.org/licenses/LGPL/2.1/
 */
 function Base() {
 };
@@ -94,7 +94,7 @@ Base.extend = function(_instance, _static) {
  *  (c) 2005 Sam Stephenson <sam@conio.net>
  *
  *  Prototype is freely distributable under the terms of an MIT-style license.
- *  For details, see the Prototype web site: http://prototype.conio.net/
+ *  For details, see the Prototype web site: https://prototype.conio.net/
  *
 /*--------------------------------------------------------------------------*/
 Function.prototype.bindAsEventListener = function(object) {

--- a/src/rabbit_jsonrpc_channel_test_app.erl
+++ b/src/rabbit_jsonrpc_channel_test_app.erl
@@ -1,7 +1,7 @@
 %% The contents of this file are subject to the Mozilla Public License
 %% Version 1.1 (the "License"); you may not use this file except in
 %% compliance with the License. You may obtain a copy of the License
-%% at http://www.mozilla.org/MPL/
+%% at https://www.mozilla.org/MPL/
 %%
 %% Software distributed under the License is distributed on an "AS IS"
 %% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://caimansys.com/painter/ (200) with 1 occurrences could not be migrated:  
   ([https](https://caimansys.com/painter/) result AnnotatedConnectException).
* http://erlang.2086793.n4.nabble.com/initializing-library-applications-without-processes-td2094473.html (200) with 1 occurrences could not be migrated:  
   ([https](https://erlang.2086793.n4.nabble.com/initializing-library-applications-without-processes-td2094473.html) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://www.getfirefox.net/ (302) with 1 occurrences migrated to:  
  https://www.getfirefox.net:443/ ([https](https://www.getfirefox.net/) result SSLHandshakeException).
* http://prototype.conio.net/ (UnknownHostException) with 1 occurrences migrated to:  
  https://prototype.conio.net/ ([https](https://prototype.conio.net/) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://creativecommons.org/licenses/LGPL/2.1/ with 1 occurrences migrated to:  
  https://creativecommons.org/licenses/LGPL/2.1/ ([https](https://creativecommons.org/licenses/LGPL/2.1/) result 301).
* http://www.mozilla.com/firefox/ with 1 occurrences migrated to:  
  https://www.mozilla.com/firefox/ ([https](https://www.mozilla.com/firefox/) result 301).
* http://www.mozilla.org/MPL/ with 1 occurrences migrated to:  
  https://www.mozilla.org/MPL/ ([https](https://www.mozilla.org/MPL/) result 301).
* http://www.mozilla.org/products/firefox/buttons/getfirefox_large2.png with 1 occurrences migrated to:  
  https://www.mozilla.org/products/firefox/buttons/getfirefox_large2.png ([https](https://www.mozilla.org/products/firefox/buttons/getfirefox_large2.png) result 301).